### PR TITLE
Add global var `mcdr_cmd_data` in plugin `minecraft_command_register`.

### DIFF
--- a/src/minecraft_command_register/minecraft_command_register/__init__.py
+++ b/src/minecraft_command_register/minecraft_command_register/__init__.py
@@ -8,6 +8,7 @@ from mcdreforged.plugin.plugin_registry import PluginCommandHolder
 
 mcdr_server: MCDReforgedServer
 
+mcdr_cmd_data = None
 
 class NodeTypes(Enum):
     LITERAL = Literal
@@ -56,6 +57,8 @@ class Node:
 
 
 def register(server: PluginServerInterface):
+    # Other plugins can access the finally returned json_data by `from minecraft_command_register import mcdr_cmd_data`.
+    global mcdr_cmd_data
     # return if server is not startup
     if not server.is_server_startup():
         return
@@ -73,6 +76,7 @@ def register(server: PluginServerInterface):
         f'\n{json.dumps(json_data, indent=4)}'
     )
     server.execute(f'mcdr register {json.dumps(json_data)}')
+    mcdr_cmd_data = json_data
     return json_data
 
 


### PR DESCRIPTION
I hope you can share MCDR command data generated by plugin `minecraft_command_register` to make other MCDR plugins can access it, so other MCDR plugin developers can use it.
> This PR is just a suggestion, I'm not expected that you'll merge it directly.