### PR TITLE
[Bug] Change to relative import to prevent import confusion

### DIFF
--- a/src/bot/bot/__init__.py
+++ b/src/bot/bot/__init__.py
@@ -1,4 +1,4 @@
-from bot.plugin import Plugin
+from .plugin import Plugin
 
 plugin: Plugin
 


### PR DESCRIPTION
# Problem
If `gugubot` loads its `bot.py` first, the following code in `bot`'s `__init__.py` will raise an error:

```python
from bot.plugin import Plugin
```

# Root Reason
The potential reason is the `bot.plugin` will try to find `plugin` attribute from `gugubot`'s `bot.py` instead of `bot`'s `bot.py`.

# Solution
Instead of using absolute import, using relative import within the `bot` package:
changing following code from
```python
from bot.plugin import Plugin
```
to
```python
from .plugin import Plugin
```

# Result
In my local testing server, the modified `bot` plugin can be loaded correctly.

# Apologize
Sorry for changing `bot` without any approval from you. 

Wish MCDR community can be better!