### PR TITLE
chore(gamemode): some features and bux fixes

### DIFF
--- a/src/gamemode/gamemode/__init__.py
+++ b/src/gamemode/gamemode/__init__.py
@@ -74,6 +74,7 @@ class ConfigV2(Serializable):
     config_version: int = 2
     permissions: Permissions = Permissions()
     short_command: ShortCommand = ShortCommand()
+    data_save_path: str = ''
 
 @dataclass
 class Coordinate:
@@ -98,7 +99,8 @@ def on_load(server: PluginServerInterface, old):
     global config, data, minecraft_data_api
     config = load_config(server)
     data = server.load_config_simple(
-        'data.json',
+        'data.json' if config.data_save_path == '' else config.data_save_path,
+        in_data_folder=(config.data_save_path == ''),
         default_config={'data': {}},
         echo_in_console=False
     )['data']
@@ -285,7 +287,10 @@ def on_load(server: PluginServerInterface, old):
 
 
 def save_data(server: PluginServerInterface):
-    server.save_config_simple({'data': data}, 'data.json')
+    server.save_config_simple({'data': data},
+        'data.json' if config.data_save_path == '' else config.data_save_path,
+        in_data_folder=(config.data_save_path == '') 
+    )
 
 
 def sur_to_spec(server, player):

--- a/src/gamemode/gamemode/__init__.py
+++ b/src/gamemode/gamemode/__init__.py
@@ -123,39 +123,28 @@ def on_load(server: PluginServerInterface, old):
         pos = ''
         humpos = ''
 
+        player_original_pos = minecraft_data_api.get_player_coordinate(src.player)
+        player_original_dim = DIMENSIONS[str(minecraft_data_api.get_player_dimension(src.player))]
+
         if len(params) == 1:  # only dimension
             if params[0] not in DIMENSIONS.keys():
                 src.reply('§c没有此维度')
-            elif DIMENSIONS[params[0]] == DIMENSIONS[
-                minecraft_data_api.get_player_info(src.player, 'Dimension')
-            ]:
+            elif DIMENSIONS[params[0]] == player_original_dim:
                 src.reply('§c您正在此维度！')
-            elif (DIMENSIONS[params[0]] == 'minecraft:the_nether') and (
-                    DIMENSIONS[
-                        minecraft_data_api.get_player_info(
-                            src.player, 'Dimension'
-                        )
-                    ] == 'minecraft:overworld'):
+            elif (DIMENSIONS[params[0]] == 'minecraft:the_nether') and (player_original_dim == 'minecraft:overworld'):
                 dim = DIMENSIONS[params[0]]
                 orgpos = [
-                    str(x) for x in
-                    minecraft_data_api.get_player_info(src.player, 'Pos')
+                    str(x) for x in player_original_pos
                 ]
                 newposx, newposz = overworld_to_nether(orgpos[0], orgpos[2])
                 pos = ' '.join((str(newposx), orgpos[1], str(newposz)))
                 humpos = ' '.join(
                     (str(newposx), str(int(float(orgpos[1]))), str(newposz))
                 )
-            elif (DIMENSIONS[params[0]] == 'minecraft:overworld') and (
-                    DIMENSIONS[
-                        minecraft_data_api.get_player_info(
-                            src.player, 'Dimension'
-                        )
-                    ] == 'minecraft:the_nether'):
+            elif (DIMENSIONS[params[0]] == 'minecraft:overworld') and (player_original_dim == 'minecraft:the_nether'):
                 dim = DIMENSIONS[params[0]]
                 orgpos = [
-                    str(x) for x in
-                    minecraft_data_api.get_player_info(src.player, 'Pos')
+                    str(x) for x in player_original_pos
                 ]
                 newposx, newposz = nether_to_overworld(orgpos[0], orgpos[2])
                 pos = ' '.join((str(newposx), orgpos[1], str(newposz)))
@@ -171,9 +160,7 @@ def on_load(server: PluginServerInterface, old):
             if not coordValid(params[0]):
                 src.reply('§c坐标不合法')
             else:
-                dim = DIMENSIONS[
-                    minecraft_data_api.get_player_info(src.player, 'Dimension')
-                ]
+                dim = player_original_dim
                 pos = ' '.join(
                     (
                         str(float(params[0])),
@@ -222,12 +209,8 @@ def on_load(server: PluginServerInterface, old):
             dim = data[src.player]['back']['dim']
             pos = [str(x) for x in data[src.player]['back']['pos']]
             data[src.player]['back'] = {
-                'dim': DIMENSIONS[
-                    minecraft_data_api.get_player_info(
-                        src.player, 'Dimension'
-                    )
-                ],
-                'pos': minecraft_data_api.get_player_info(src.player, 'Pos')
+                'dim': DIMENSIONS[str(minecraft_data_api.get_player_dimension(src.player))],
+                'pos': minecraft_data_api.get_player_coordinate(src.player)
             }
             save_data(server)
             server.execute(
@@ -290,8 +273,8 @@ def save_data(server: PluginServerInterface):
 
 
 def sur_to_spec(server, player):
-    dim = DIMENSIONS[minecraft_data_api.get_player_info(player, 'Dimension')]
-    pos = minecraft_data_api.get_player_info(player, 'Pos')
+    dim = DIMENSIONS[str(minecraft_data_api.get_player_dimension(player))]
+    pos = minecraft_data_api.get_player_coordinate(player)
     data[player] = {
         'dim': dim,
         'pos': pos,

--- a/src/gamemode/gamemode/__init__.py
+++ b/src/gamemode/gamemode/__init__.py
@@ -135,6 +135,8 @@ def on_load(server: PluginServerInterface, old):
             """
             Check if the given coordinate is valid
             """
+            if coord == '~':
+                return True
             if coord.count('-') > 1 or coord.count('.') > 1 or coord.startswith(
                     '.') or coord.endswith('.'):
                 return False
@@ -206,21 +208,26 @@ def on_load(server: PluginServerInterface, old):
                 to_coordinate.z = 0
 
         elif len(params) == 3:  # only position: e.g. !!tp x y z
-            if not coordValid(params[0]):
+            if (not coordValid(params[0])) or (not coordValid(params[1])) or (not coordValid(params[2])):
                 return src.reply('§c坐标不合法')
+            if (params[0] == '~' and params[1] == '~' and params[2] == '~'):
+                return src.reply('§c原地 tp 是吧 (doge)')
             to_coordinate_dim = player_original_dim
-            to_coordinate.x = float(params[0])
-            to_coordinate.y = float(params[1])
-            to_coordinate.z = float(params[2])
+            to_coordinate.x = float(params[0] if params[0] != '~' else player_original_pos.x)
+            to_coordinate.y = float(params[1] if params[1] != '~' else player_original_pos.y)
+            to_coordinate.z = float(params[2] if params[2] != '~' else player_original_pos.z)
 
         elif len(params) == 4:  # dimension + position: e.g. !!tp the_end x y z
             if params[0] not in DIMENSIONS.keys():
                 return src.reply('§c没有此维度')
-
+            if (player_original_dim == DIMENSIONS[params[0]] and params[1] == '~' and params[2] == '~' and params[3] == '~'):
+                return src.reply('§c原地 tp 是吧 (doge)')
+            
+            tp_type = "to_coordinate"
             to_coordinate_dim = DIMENSIONS[params[0]]
-            to_coordinate.x = float(params[1])
-            to_coordinate.y = float(params[2])
-            to_coordinate.z = float(params[3])
+            to_coordinate.x = float(params[1] if params[1] != '~' else player_original_pos.x)
+            to_coordinate.y = float(params[2] if params[2] != '~' else player_original_pos.y)
+            to_coordinate.z = float(params[3] if params[3] != '~' else player_original_pos.z)
 
         data[src.player]['back'] = {
             'dim': player_original_dim,
@@ -283,14 +290,14 @@ def on_load(server: PluginServerInterface, old):
             Text('param1')
             .runs(tp).  # !!tp <dimension | player> -- param1 = dimension or player name
             then(
-                Float('param2')
+                Text('param2')
                 .then(
-                    Float('param3')
+                    Text('param3')
                     # !!tp <x> <y> <z> -- param1 = x, param2 = y, param3 = z
                     .runs(tp)
                     .then(
                         # !!tp <dimension> <x> <y> <z> -- param1 = dimension, param2 = x, param3 = y, param4 = z
-                        Float('param4')
+                        Text('param4')
                         .runs(tp)
                     )
                 )

--- a/src/gamemode/gamemode/__init__.py
+++ b/src/gamemode/gamemode/__init__.py
@@ -31,11 +31,17 @@ HUMDIMS = {
     'minecraft:the_end': '末地'
 }
 
-HELP_MESSAGE = '''§6!!spec §7旁观/生存切换
+HELP_MESSAGE = '''§6!!spec §7切换旁观/生存
 §6!!spec <player> §7切换他人模式
-§6!!tp [dimension] [position] §7传送至指定地点
+§6!!tp <dimension> §7传送至指定维度（主世界与下界自动换算坐标）
+§6!!tp [dimension] <x> <y> <z> §7传送至（指定维度的）指定坐标
 §6!!back §7返回上个地点'''
 
+HELP_MESSAGE_WITH_SHORT_COMMAND = '''§6!!spec §7或§6 {0} §7切换旁观/生存
+§6!!spec <player> §7或§6 {0} <player> §7切换他人模式
+§6!!tp <dimension> §7传送至指定维度（主世界与下界自动换算坐标）
+§6!!tp [dimension] <x> <y> <z> §7传送至（指定维度的）指定坐标
+§6!!back §7返回上个地点'''
 
 class ConfigV1(Serializable):
     short_command: bool = True
@@ -63,6 +69,7 @@ class ConfigV2(Serializable):
         back: int = 1
     class ShortCommand(Serializable):
         enabled: bool = False
+        command: str = "!s"
 
     config_version: int = 2
     permissions: Permissions = Permissions()
@@ -230,7 +237,7 @@ def on_load(server: PluginServerInterface, old):
     # spec literals
     spec_literals = ['!!spec']
     if config.short_command.enabled:
-        spec_literals.append('!s')
+        spec_literals.append(config.short_command.command)
 
     # register
     server.register_command(
@@ -239,7 +246,7 @@ def on_load(server: PluginServerInterface, old):
         .runs(change_mode)
         .then(
             Literal('help')
-            .runs(lambda src: src.reply(HELP_MESSAGE))
+            .runs(lambda src: src.reply(HELP_MESSAGE_WITH_SHORT_COMMAND.format(config.short_command.command) if config.short_command.enabled else HELP_MESSAGE))
         )
         .then(
             Text('player')

--- a/src/gamemode/gamemode/__init__.py
+++ b/src/gamemode/gamemode/__init__.py
@@ -321,9 +321,11 @@ def save_data(server: PluginServerInterface):
 def sur_to_spec(server, player):
     dim = DIMENSIONS[str(minecraft_data_api.get_player_dimension(player))]
     pos = minecraft_data_api.get_player_coordinate(player)
+    rotation = minecraft_data_api.get_player_info(player, 'Rotation')
     data[player] = {
         'dim': dim,
         'pos': pos,
+        'rotation': rotation,
         'time': time.time(),
         'back': {
             'dim': dim,
@@ -339,6 +341,9 @@ def spec_to_sur(server, player):
     pos = [str(x) for x in data[player]['pos']]
     server.execute(
         'execute in {} run tp {} {}'.format(dim, player, ' '.join(pos)))
+    if 'rotation' in data[player]:
+        rotation = data[player]['rotation']
+        server.execute(f'rotate {player} {str(rotation[0])} {str(rotation[1])}')
     server.execute(f'gamemode survival {player}')
     del data[player]
     save_data(server)

--- a/src/gamemode/readme.md
+++ b/src/gamemode/readme.md
@@ -1,6 +1,6 @@
 # Gamemode
 
-> 高级版灵魂出窍(切旁观, 切回生存传送回原位置)
+> 高级版灵魂出窍 (切旁观, 切回生存传送回原位置)
 
 感谢 [方块君](https://github.com/Squaregentleman) 的 [gamemode](https://github.com/Squaregentleman/MCDR-plugins) 插件
 
@@ -10,42 +10,95 @@
 
 ## 使用
 
-`!!spec` / `!s` 旁观/生存切换
+`!!spec` 切换旁观/生存
 
-`!!tp <dimension> [position]` 传送至指定地点
+`!!spec <player>` 切换他人模式
+
+`!!tp <player>` 传送至指定玩家
+
+`!!tp <dimension>` 传送至指定维度（主世界与下界自动换算坐标）
+
+`!!tp [dimension] <x> <y> <z>` 传送至（指定维度的）指定坐标
 
 `!!back` 返回上个地点
 
+若启用了 `short_command`, 可使用配置的短命令 (如: `!s`) 实现与 `!!spec` 相同的效果
+
 ## 配置
 
-### short_command
+默认配置如下:
 
-默认值: `True`
+```json
+{
+    "config_version": 2,
+    "permissions": {
+        "spec": 1,
+        "spec_other": 2,
+        "tp": 1,
+        "back": 1
+    },
+    "short_command": {
+        "enabled": false,
+        "command": "!s"
+    },
+    "data_save_path": ""
+}
+```
 
-是否启用短命令
+### `config_version`
 
-### 其他数字配置是权限
+配置文件版本, 请不要更改
 
-`spec`
+### `permissions`
+
+各种操作所需的最低权限
+
+#### `spec`
 
 默认值: `1`
 
-使用 `!!spec` 的最低权限
+使用 `!!spec` 与 `short_command` (若启用) 的最低权限
 
-`spec_other`
+#### `spec_other`
 
 默认值: `2`
 
-使用 `!!spec <player` 的最低权限
+使用 `!!spec <player>` 的最低权限
 
-`tp`
+#### `tp`
 
 默认值: `1`
 
-使用 `!!tp <dimension> [position]` 的最低权限
+使用 `!!tp <player>`、`!!tp <dimension>`、`!!tp [dimension] <x> <y> <z>` 的最低权限
 
-`back`
+#### `back`
 
 默认值: `1`
 
 使用 `!!back` 的最低权限
+
+### `short_command`
+
+短命令相关
+
+#### `enabled`
+
+默认值: `false`
+
+是否启用短命令
+
+#### `command`
+
+默认值: `!s`
+
+`!!spec` 命令的别名. 运行此命令的权限要求与 `!!spec` 相同
+
+### `data_save_path`
+
+默认值: (空)
+
+用于设置存储正处于旁观模式的玩家的信息 (如: 他们生存切旁观时的位置) 等数据的文件的位置.
+
+为空 (默认) 时存储于 `config/gamemode/config.json`
+
+如果你同时安装了其他备份插件 (如 Prime Backup), 则建议将此文件放置于存档内而不是默认的存档外, 防止回档后玩家的 "旁观" 没有回档. 例如: `server/world/mcdr-plugin-config/gamemode/data.json`.


### PR DESCRIPTION
关于 [`Gamemode`](https://github.com/AnzhiZhang/MCDReforgedPlugins/tree/master/src/gamemode) 的一些更新:

---

- **[commit 13e80c9](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/13e80c97c218f7e0b63d640a7a386c5454de30ec)** perf: 修复 if 语句的条件中, 重复查询玩家坐标与维度, 浪费 IO 的问题; 使用 minecraft data api 提供的 `minecraft_data_api.get_player_dimension(player)`  而不是 `minecraft_data_api.get_player_info(player, 'Dimension')` 来查询玩家所在维度 (坐标同理), 减轻后续维护成本.

- **[commit 2feb1c4](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/2feb1c4402d55771bb95a11de761a1c4f606354d)** fix: 修复 `!!spec <player>` 中, 若玩家不存在将导致报错的 bug:

```
[Server] [Server thread/INFO]: <Player> !!spec ghost
[Server] [Server thread/INFO]: No entity was found
[MCDR] [Gamemode switch mode/WARNING] [minecraft_data_api]: Query for player ghost at path Dimension timeout
Exception in thread Gamemode switch mode:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/site-packages/mcdreforged/api/decorator/new_thread.py", line 29, in wrapped_target
    raise e from None
  File "/usr/local/lib/python3.12/site-packages/mcdreforged/api/decorator/new_thread.py", line 26, in wrapped_target
    self.__return_value = target(*args_, **kwargs_)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "plugins/Gamemode-v1.1.0.mcdr/gamemode/__init__.py", line 88, in change_mode
  File "plugins/Gamemode-v1.1.0.mcdr/gamemode/__init__.py", line 293, in sur_to_spec
KeyError: None
```

此外, 玩家名称大小写错误也会报错 (例如: `!!spec steve` (应该是 Steve), 也会报错), 此 commit 一并修复了此问题, 现在 `<player>` 不再区分大小写

- **[commit d179ed5](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/d179ed5ee729e7dcb2457622245b6e7a104e1a84)** feat!: 升级 (修改) 配置文件格式, 增加其可读性, 为其他 features 提供前提

不改改格式的话再加新功能配置文件就会很乱

读取配置文件时不用 `PluginServerInterface.load_config_simple` 是而手动读取是因为其限制过多, 试了半天都无法实现转换配置文件版本 (其实也不是不能用, 就是要读取两次, 浪费 IO), 目前遇到的限制如下:

  - `default_config` 与 `target_class` 必须有一个
  - 自动删除配置文件中存在, 但 `default_config` 中不存在的 keys, 也就是说不能给 `default_config` 传 `{}` 实现仅读取文件
  - 会有一些特殊情况, 使即使 `data_processor` 返回了 False 也会覆写文件, 导致配置丢失

当然也有可能是我太菜了, 没研究明白怎么搞

- **[commit 0917cb8](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/0917cb82b6da8fb698b846c22d3ce36ba1999a4a)** refactor: 删减修改大量坐标拼接等操作, 提升代码可读性

主要更改: 原代码中一堆 `dim`, `pos`, `humpos` 的重复手动拼接, 现在将其统一挪到后面一起拼接了; 使用 early return 替换掉部分 if - else 嵌套, 降低复杂度.

- **[commit a9f95b3](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/a9f95b30c5a2f328651f67901a614ce7f202821c)** feat: 允许用户自行通过 `short_command` 配置 `!!spec` 的别名 (默认为 `!s`); 更新帮助信息

之前一直想把 `!s` 改成 `!c`, 不过现在用习惯了觉得这样也挺好的, 不过多提供一个选项总不是坏事.

- **[commit 7a036f2](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/7a036f27f26daaf44175a8d7cf34e84b0c081097)** feat: 允许用户自行通过 `data_save_path` 配置 `data.json` 的存储位置

如果同时装了 Prime Backup 等备份插件, 容易出现回档后 "旁观" 没回档的情况 (简单复现: 切旁观, 回档, 切生存, 此时人会被传回回档前切旁观的位置), 此时希望有一个配置, 能够将 data.json 存到存档里, 这样回档就能一起回了.

- **[commit 03a4cab](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/03a4cab578b1279accf7cc5e77aa0c72946d9797)** feat: 新增 `!!tp <player>` 命令, 用于传送到玩家

例如: `!!tp Steve` 传送到 Steve. `<player>` 不区分大小写 (自动纠正大小写)

尽管旁观下鼠标中键就能传送到玩家, 但是不能传送到同在旁观的玩家 (tweakeroo 可以, 但是 not vanilla, 且不是每个人都装了这个 mod 的), 因此需要一个命令来传送到玩家

- **[commit c033757](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/c033757362d5dfa05ab4d78ab1853e5025b5fa09)** feat: 新增 `!!tp [dimension] <x> <y> <z>` 中坐标支持为 `~` (当前坐标) 功能

例如: `!!tp 0 ~ 0`, `!!tp end 0 ~ 0`

玩家: 我只是想传到相同高度, 不想每次都再输一遍 y 轴

- **[commit 9a606ea](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/9a606eacc910140e39c37fa8b49ddece4c764402)** feat: 切回生存后, 不仅将玩家传回原处, 而且将玩家旋转角度也设置回去

不然每次切回去总会看着奇奇怪怪的地方, 还得手动旋转视角, 看看自己究竟在哪, 比较麻烦

- **[commit 98aad20](https://github.com/DuckBurnIncense/MCDReforgedPlugins-fork/commit/98aad2072667693268ebf687777aa8429ee099ca)** docs: 更新 README

把这些更改 (尤其是配置文件更改) 记录到 README 里

---

**BREAKING CHANGE**: 修改配置文件格式. 尽管会自动转换格式, 但仍可能带来兼容性问题

---

一些补充说明:

- 我平时写 js 偏多, 对 python 并不算熟悉, 因此可能有些格式错误, 甚至 bug 出现, 还请仔细 review 后再合并
- 我已经尽可能地大量测试了, 并没有发现有问题
- 由于包含了多类小 commit, 这个 pr 标题我是真想不出来咋写了, 或许我应该为每个 commit 单独开一个 pr?
- <del>修复了已有 bug, 引入了新的 bug</del>