### PR TITLE
feat(bot): ✨ 更新 Carpet 假人行为 / align Carpet bot behavior

### DIFF
--- a/src/bot/bot/bot.py
+++ b/src/bot/bot/bot.py
@@ -48,6 +48,8 @@ class Bot:
         self.__mc_name: str = ''
         self.__online: bool = False
         self.__saved: bool = False
+        self.__spawning_since = None
+        self.__spawn_target_name = None
 
     @property
     def name(self):
@@ -92,6 +94,27 @@ class Bot:
     @property
     def online(self):
         return self.__online
+
+    @property
+    def spawning(self) -> bool:
+        """Whether Carpet is still resolving and spawning this fake player."""
+        if self.__spawning_since is None:
+            return False
+
+        timeout = self.__plugin.config.spawn_timeout
+        if timeout > 0 and time.monotonic() - self.__spawning_since >= timeout:
+            self.__spawning_since = None
+            self.__spawn_target_name = None
+            self.__server.logger.warning(
+                f'Timed out waiting for bot "{self.name}" to join'
+            )
+            return False
+        return True
+
+    @property
+    def pending_spawn_name(self):
+        """The exact Minecraft name requested in the current spawn."""
+        return self.__spawn_target_name if self.spawning else None
 
     @property
     def saved(self):
@@ -180,6 +203,44 @@ class Bot:
         :param online: A bool.
         """
         self.__online = online
+        self.__spawning_since = None
+        self.__spawn_target_name = None
+
+    def set_spawning(
+            self,
+            spawning: bool,
+            target_name: str = None
+    ) -> None:
+        """Set the transient state used while Carpet resolves a profile."""
+        if spawning:
+            self.__spawning_since = time.monotonic()
+            self.__spawn_target_name = target_name or self.name
+        else:
+            self.__spawning_since = None
+            self.__spawn_target_name = None
+
+    def matches_pending_spawn(self, mc_name: str) -> bool:
+        """Match a join against the exact name sent to Carpet."""
+        pending_name = self.pending_spawn_name
+        return (
+            pending_name is not None and
+            pending_name.lower() == mc_name.lower()
+        )
+
+    def restore_runtime_state(
+            self,
+            mc_name: str,
+            online: bool,
+            spawning: bool = False,
+            pending_spawn_name: str = None
+    ) -> None:
+        """Restore non-persistent state after a hot reload."""
+        self.__mc_name = mc_name
+        self.__online = online
+        self.set_spawning(
+            spawning and not online,
+            pending_spawn_name or self.name
+        )
 
     def set_saved(self, saved: bool) -> None:
         """
@@ -192,15 +253,27 @@ class Bot:
         """
         Spawn the bot.
         """
-        if not self.__online:
-            self.__server.execute(
-                'player {} spawn at {} facing {} in {}'.format(
-                    self.name,
-                    ' '.join(map(str, self.location.position)),
-                    ' '.join(map(str, self.location.facing)),
-                    self.location.str_dimension
-                )
+        if not self.__online and not self.spawning:
+            command = 'player {} spawn at {} facing {} in {}'.format(
+                self.name,
+                ' '.join(map(str, self.location.position)),
+                ' '.join(map(str, self.location.facing)),
+                self.location.str_dimension
             )
+
+            # Carpet uses creative mode when a spawn command comes from the
+            # console.  Passing the mode as part of the spawn command avoids
+            # the asynchronous join/gamemode race while preserving the old
+            # behaviour for unsaved temporary bots.
+            if self.saved or self.__plugin.config.force_gamemode:
+                command += f' in {self.__plugin.config.gamemode}'
+
+            self.set_spawning(True, self.name)
+            try:
+                self.__server.execute(command)
+            except Exception:
+                self.set_spawning(False)
+                raise
         else:
             raise BotOnlineException(self.name)
 
@@ -236,12 +309,24 @@ class Bot:
         if self.__online:
             # auto update location
             if self.auto_update:
-                self.set_location(self.__plugin.get_location(self.mc_name))
-                self.__plugin.bot_manager.save_data()
+                previous_location = self.location
+                try:
+                    self.set_location(self.__plugin.get_location(self.mc_name))
+                    self.__plugin.bot_manager.save_data()
+                except Exception:
+                    # A data query failure must not make a fake player
+                    # impossible to remove.  Keep the last saved location and
+                    # continue with Carpet's kill command.
+                    self.set_location(previous_location)
+                    self.__server.logger.warning(
+                        f'Failed to update location for bot "{self.name}" '
+                        'before killing it; keeping the previous location',
+                        exc_info=True
+                    )
 
             # kill
+            self.__server.execute(f'player {self.mc_name or self.name} kill')
             self.set_online(False)
-            self.__server.execute(f'player {self.mc_name} kill')
         else:
             raise BotOfflineException(self.name)
 
@@ -262,13 +347,20 @@ class Bot:
 
         # Run actions
         for action in run_actions:
-            self.__server.execute(f'player {self.mc_name} {action}')
+            self.run_action(action)
+
+    def run_action(self, action: str) -> None:
+        """Run one Carpet action without modifying the saved action list."""
+        self.__server.execute(
+            f'player {self.mc_name or self.name} {action}'
+        )
 
     def __str__(self):
         return (
                 self.__class__.__name__ +
                 dict(**self.saving_data, **{
                     'online': self.online,
+                    'spawning': self.spawning,
                     'saved': self.saved
                 }).__str__()
         )

--- a/src/bot/bot/bot_manager.py
+++ b/src/bot/bot/bot_manager.py
@@ -2,8 +2,6 @@ import math
 import datetime
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
-from mcdreforged.api.decorator import new_thread
-
 from bot.bot import Bot
 from bot.exceptions import *
 from bot.location import Location
@@ -18,15 +16,23 @@ class BotManager:
         self.__plugin: 'Plugin' = plugin
         self.__bots: Dict[str, Bot] = {}
 
-        self.__load_data(prev_module)
+        # Persistent and previous runtime data must be available before
+        # commands and HTTP routes are registered, so an early save can never
+        # overwrite an empty or half-loaded bot list.
+        self.__load_saved_data()
+        if prev_module is not None:
+            self.__restore_previous_state(prev_module)
+
+        self.__plugin.server.logger.debug(f'Loaded {len(self.bots)} bots:')
+        for bot in self.__bots.values():
+            self.__plugin.server.logger.debug(f'  - {bot}')
 
     @property
     def bots(self) -> Dict[str, Bot]:
         return self.__bots
 
-    @new_thread('loadBot')
-    def __load_data(self, prev_module) -> None:
-        # saved bots
+    def __load_saved_data(self) -> None:
+        """Synchronously load all persistent bot records."""
         file_data = self.__plugin.server.load_config_simple(
             DATA_FILE_NAME,
             default_config={'botList': []},
@@ -34,13 +40,14 @@ class BotManager:
         )['botList']
         for bot_data in file_data:
             name = bot_data['name']
-            self.__bots[name] = self.new_bot(
+            location = Location.from_dict(bot_data.get('location', {
+                'position': [0.0, 0.0, 0.0],
+                'facing': [0.0, 0.0],
+                'dimension': 0
+            }))
+            bot = self.new_bot(
                 name,
-                Location.from_dict(bot_data.get('location', {
-                    'position': [0.0, 0.0, 0.0],
-                    'facing': [0.0, 0.0],
-                    'dimension': 0
-                })),
+                location,
                 bot_data.get('comment', ''),
                 bot_data.get('actions', []),
                 bot_data.get('tags', []),
@@ -48,22 +55,38 @@ class BotManager:
                 bot_data.get('autoRunActions', False),
                 bot_data.get('autoUpdate', False)
             )
-            self.__bots[name].set_saved(True)
+            bot.set_saved(True)
 
-        # old bots
-        if prev_module is not None:
-            old_self: 'BotManager' = prev_module.plugin.bot_manager
-            api = self.__plugin.minecraft_data_api
-            online_list = api.get_server_player_list()[2]
-            for name in online_list:
-                name = self.__plugin.parse_name(name)
-                if old_self.is_in_list(name):
-                    self.__bots[name] = old_self.get_bot(name)
-                    self.__bots[name].set_online(True)
+    def __restore_previous_state(self, prev_module) -> None:
+        """Synchronously copy runtime state into fresh Bot objects."""
+        old_self: 'BotManager' = prev_module.plugin.bot_manager
+        for old_bot in list(old_self.bots.values()):
+            online = old_bot.online
+            spawning = getattr(old_bot, 'spawning', False)
+            if not online and not spawning:
+                continue
 
-        self.__plugin.server.logger.debug(f'Loaded {len(self.bots)} bots:')
-        for i in self.__bots.values():
-            self.__plugin.server.logger.debug(f'  - {i}')
+            name = old_bot.name
+            if self.is_in_list(name):
+                bot = self.get_bot(name)
+            else:
+                data = old_bot.saving_data
+                bot = self.new_bot(
+                    name,
+                    Location.from_dict(data['location']),
+                    data['comment'],
+                    data['actions'],
+                    data['tags'],
+                    data['autoLogin'],
+                    data['autoRunActions'],
+                    data['autoUpdate']
+                )
+            bot.restore_runtime_state(
+                old_bot.mc_name or name,
+                online,
+                spawning,
+                getattr(old_bot, 'pending_spawn_name', None)
+            )
 
     def save_data(self) -> None:
         self.__plugin.server.save_config_simple(
@@ -103,7 +126,7 @@ class BotManager:
         self.__bots = {
             bot.name: bot
             for bot in self.bots.values()
-            if bot.online or bot.saved
+            if bot.online or bot.saved or bot.spawning
         }
 
     def get_bots_by_tag(self, tag: str) -> List[Bot]:
@@ -261,6 +284,16 @@ class BotManager:
                 raise BotOfflineException(name)
         else:
             raise BotNotExistsException(name)
+
+    def direct_action(self, name: str, action: str) -> Bot:
+        """Run a one-off Carpet action on an online bot."""
+        if self.is_in_list(name):
+            bot = self.get_bot(name)
+            if bot.online:
+                bot.run_action(action)
+                return bot
+            raise BotOfflineException(name)
+        raise BotNotExistsException(name)
 
     def save(
             self,

--- a/src/bot/bot/command_handler.py
+++ b/src/bot/bot/command_handler.py
@@ -8,7 +8,11 @@ from mcdreforged.api.decorator import new_thread
 from more_command_nodes import Position, Facing, EnumeratedText
 
 from bot.exceptions import *
-from bot.constants import DIMENSION
+from bot.constants import (
+    DIMENSION,
+    CARPET_ACTIONS,
+    CARPET_ACTIONS_WITHOUT_ARGUMENTS,
+)
 from bot.location import Location
 
 if TYPE_CHECKING:
@@ -25,7 +29,11 @@ class CommandHandler:
             return lambda: [
                 name for name, bot in
                 self.__plugin.bot_manager.bots.items()
-                if online is None or bot.online == online
+                if (
+                    online is None or
+                    (online and bot.online) or
+                    (not online and not bot.online and not bot.spawning)
+                )
             ]
 
         def create_subcommand(literal: str) -> Literal:
@@ -77,15 +85,37 @@ class CommandHandler:
 
         def make_action_command() -> Literal:
             action_literal = create_subcommand('action')
-            action_literal.then(
+            name_node = (
                 Text('name')
                 .runs(self.__command_action)
                 .suggests(bot_list(True))
-                .then(
-                    Integer('index')
-                    .runs(self.__command_action)
-                )
             )
+            name_node.then(
+                Integer('index')
+                .runs(self.__command_action)
+            )
+
+            # Keep the existing saved-action/index syntax and add the current
+            # Carpet action roots as literal branches.  Literal nodes are
+            # matched before the Integer index node by MCDR, so old numeric
+            # invocations remain unambiguous.
+            for action, suggestions in CARPET_ACTIONS.items():
+                carpet_action = Literal(action)
+                if action in CARPET_ACTIONS_WITHOUT_ARGUMENTS:
+                    carpet_action.runs(
+                        self.__make_direct_action_callback(action)
+                    )
+                if suggestions:
+                    carpet_action.then(
+                        GreedyText('carpetActionArguments')
+                        .suggests(
+                            self.__make_suggestion_callback(suggestions)
+                        )
+                        .runs(self.__make_direct_action_callback(action))
+                    )
+                name_node.then(carpet_action)
+
+            action_literal.then(name_node)
             return action_literal
 
         def make_tags_command() -> Literal:
@@ -467,6 +497,34 @@ class CommandHandler:
                 'bot.error.illegalActionIndex', e.index
             ))
 
+    @staticmethod
+    def __make_suggestion_callback(suggestions):
+        def callback():
+            return suggestions
+        return callback
+
+    def __make_direct_action_callback(self, action: str):
+        def callback(src: CommandSource, ctx: CommandContext):
+            arguments = ctx.get('carpetActionArguments')
+            command = action if arguments is None else f'{action} {arguments}'
+            self.__command_direct_action(src, ctx, command)
+        return callback
+
+    def __command_direct_action(
+            self,
+            src: CommandSource,
+            ctx: CommandContext,
+            action: str
+    ):
+        name = self.__plugin.parse_name(ctx['name'])
+        try:
+            self.__plugin.bot_manager.direct_action(name, action)
+            src.reply(RTextMCDRTranslation('bot.command.action', name))
+        except BotNotExistsException as e:
+            src.reply(RTextMCDRTranslation('bot.error.botNotExists', e.name))
+        except BotOfflineException as e:
+            src.reply(RTextMCDRTranslation('bot.error.botOffline', e.name))
+
     def __command_tag_list(self, src: CommandSource):
         # header
         message = RTextList('-------- List --------')
@@ -513,7 +571,7 @@ class CommandHandler:
             # spawn
             counter = 0
             for bot in self.__plugin.bot_manager.get_bots_by_tag(tag):
-                if not bot.online:
+                if not bot.online and not bot.spawning:
                     bot.spawn()
                     counter += 1
 

--- a/src/bot/bot/config.py
+++ b/src/bot/bot/config.py
@@ -9,6 +9,7 @@ class Config(Serializable):
     name_prefix: str = 'bot_'
     name_suffix: str = ''
     post_join_delay: int = 0
+    spawn_timeout: float = 30.0
     permissions: Dict[str, int] = {
         'list': 1,
         'spawn': 1,

--- a/src/bot/bot/constants.py
+++ b/src/bot/bot/constants.py
@@ -3,6 +3,46 @@ DATA_FILE_NAME = 'botList.json'
 BIN_FILE_NAME = 'botBin.json'
 
 
+# Carpet ``/player`` action roots that can safely be forwarded to an online
+# fake player.  Lifecycle operations (spawn / kill) keep using the dedicated
+# Bot manager commands so its online state and auto-update behaviour stay in
+# sync.
+CARPET_ACTIONS = {
+    'stop': (),
+    'use': ('once', 'continuous', 'interval 20'),
+    'jump': ('once', 'continuous', 'interval 20'),
+    'attack': ('once', 'continuous', 'interval 20'),
+    'drop': (
+        'once', 'continuous', 'interval 20',
+        'all', 'mainhand', 'offhand', '0'
+    ),
+    'dropStack': (
+        'once', 'continuous', 'interval 20',
+        'all', 'mainhand', 'offhand', '0'
+    ),
+    'swapHands': ('once', 'continuous', 'interval 20'),
+    'hotbar': ('1', '2', '3', '4', '5', '6', '7', '8', '9'),
+    'mount': ('anything',),
+    'dismount': (),
+    'sneak': (),
+    'unsneak': (),
+    'sprint': (),
+    'unsprint': (),
+    'look': (
+        'north', 'south', 'east', 'west', 'up', 'down',
+        'at ~ ~ ~', '~ ~'
+    ),
+    'turn': ('left', 'right', 'back', '~ ~'),
+    'move': ('forward', 'backward', 'left', 'right'),
+}
+
+# These actions are valid without an additional argument in Carpet v26.2.
+CARPET_ACTIONS_WITHOUT_ARGUMENTS = {
+    'stop', 'use', 'jump', 'attack', 'drop', 'dropStack', 'swapHands',
+    'mount', 'dismount', 'sneak', 'unsneak', 'sprint', 'unsprint', 'move'
+}
+
+
 class DIMENSION:
     OVERWORLD = 0
     THE_NETHER = -1

--- a/src/bot/bot/event_handler.py
+++ b/src/bot/bot/event_handler.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 plugin: 'Plugin'
 
+CARPET_LOCAL_LOGIN = re.compile(
+    r'\[(?:local(?::[^\]]*)?)\]'
+)
+
 
 class EventHandler:
     def __init__(self, plg: 'Plugin'):
@@ -29,7 +33,7 @@ class EventHandler:
     @event_listener(MCDRPluginEvents.SERVER_STOP)
     def on_server_stop(server: PluginServerInterface, server_return_code: int):
         for bot in plugin.bot_manager.bots.values():
-            if bot.online:
+            if bot.online or bot.spawning:
                 bot.set_online(False)
         plugin.bot_manager.update_list()
 
@@ -41,12 +45,40 @@ class EventHandler:
             player: str,
             info: Info
     ):
-        if re.fullmatch(
-                r'\w+\[local] logged in with entity id \d+ at \(.*\)',
-                info.content
+        # Carpet fake players use a local connection.  Requiring that marker
+        # prevents a real player with a colliding configured prefix/suffix
+        # from being treated as a bot while an asynchronous spawn is pending.
+        is_local_login = (
+            CARPET_LOCAL_LOGIN.search(info.content or '') is not None
+        )
+        if not is_local_login:
+            return
+
+        name = plugin.parse_name(player)
+        known_bot = (
+            plugin.bot_manager.get_bot(name)
+            if plugin.bot_manager.is_in_list(name)
+            else None
+        )
+        is_matching_pending = (
+            known_bot is not None and
+            known_bot.matches_pending_spawn(player)
+        )
+
+        # A differently named local login can normalize to the same logical
+        # bot name.  Do not let it consume or overwrite an active request.
+        if (
+                known_bot is not None and
+                known_bot.spawning and
+                not is_matching_pending
         ):
-            # parse name
-            name = plugin.parse_name(player)
+            server.logger.warning(
+                f'Ignored local player "{player}" while waiting for bot '
+                f'"{known_bot.pending_spawn_name}"'
+            )
+            return
+
+        if is_matching_pending or is_local_login:
             if name != player.lower():
                 message = RText(
                     f'Warning: Bot "{player}" is not named correctly, '
@@ -60,8 +92,8 @@ class EventHandler:
             server.logger.debug(f'Bot {player} joined')
 
             # To Bot instance
-            if plugin.bot_manager.is_in_list(name):
-                bot = plugin.bot_manager.get_bot(name)
+            if known_bot is not None:
+                bot = known_bot
             else:
                 location = plugin.get_location(player)
                 bot = plugin.bot_manager.new_bot(name, location)
@@ -77,9 +109,11 @@ class EventHandler:
 
         # remove from list
         if plugin.bot_manager.is_in_list(name):
-            server.logger.debug(f'Bot {name} left')
-            plugin.bot_manager.get_bot(name).set_online(False)
-            plugin.bot_manager.update_list()
+            bot = plugin.bot_manager.get_bot(name)
+            if bot.online and bot.mc_name.lower() == player.lower():
+                server.logger.debug(f'Bot {name} left')
+                bot.set_online(False)
+                plugin.bot_manager.update_list()
 
     @staticmethod
     @event_listener(MCDRPluginEvents.PLUGIN_UNLOADED)

--- a/src/bot/bot/fastapi_manager.py
+++ b/src/bot/bot/fastapi_manager.py
@@ -103,10 +103,10 @@ class FastAPIManager:
     def __update_bot_data(self, bot: Bot, request: BaseBotRequest) -> None:
         # spawn or kill checking
         if request.online is not None:
-            if request.online and bot.online:
+            if request.online and (bot.online or bot.spawning):
                 raise HTTPException(
                     status_code=422,
-                    detail=f'Bot "{bot.name}" is already online.'
+                    detail=f'Bot "{bot.name}" is already online or spawning.'
                 )
             elif not request.online and not bot.online:
                 raise HTTPException(
@@ -155,7 +155,7 @@ class FastAPIManager:
 
         # spawn or kill perform
         if request.online is not None:
-            if request.online and not bot.online:
+            if request.online and not bot.online and not bot.spawning:
                 bot.spawn()
             elif not request.online and bot.online:
                 bot.kill()

--- a/src/bot/bot/plugin.py
+++ b/src/bot/bot/plugin.py
@@ -135,5 +135,35 @@ class Plugin:
         """
         api = self.minecraft_data_api
         info = api.get_player_info(name)
-        dimension = DIMENSION.INT_TRANSLATION.get(info['Dimension'])
-        return Location(info['Pos'], info['Rotation'], dimension)
+        if info is None:
+            raise ValueError(f'Failed to query location for player "{name}"')
+
+        try:
+            position = info['Pos']
+            facing = info['Rotation']
+            raw_dimension = info['Dimension']
+        except (KeyError, TypeError) as e:
+            raise ValueError(
+                f'Incomplete location data for player "{name}": {info!r}'
+            ) from e
+
+        dimension = None
+        if isinstance(raw_dimension, int):
+            if raw_dimension in DIMENSION.STR_TRANSLATION:
+                dimension = raw_dimension
+        else:
+            dimension = DIMENSION.INT_TRANSLATION.get(str(raw_dimension))
+        if dimension is None:
+            raise ValueError(
+                f'Unsupported dimension {raw_dimension!r} for player "{name}"'
+            )
+        if (
+                not isinstance(position, (list, tuple)) or
+                not isinstance(facing, (list, tuple)) or
+                len(position) != 3 or
+                len(facing) != 2
+        ):
+            raise ValueError(
+                f'Invalid location data for player "{name}": {info!r}'
+            )
+        return Location(position, facing, dimension)

--- a/src/bot/lang/en_us.yml
+++ b/src/bot/lang/en_us.yml
@@ -6,7 +6,7 @@ bot.help.content: |
   §6!!bot list [--index <index>] [filters]§7Show bot list
   §6!!bot spawn <name> §7Spawn bot
   §6!!bot kill <name> §7Kill bot
-  §6!!bot action <name> [index] §7Execute bot action(s)
+  §6!!bot action <name> [index|carpet action] §7Run saved or one-off Carpet action(s)
   §6!!bot tags §7View available tags
   §6!!bot tags <tag> spawn/kill §7Spawn/kill bot(s) with tag
   §6!!bot info <name> §7View bot info
@@ -25,13 +25,13 @@ bot.error.botOnline: §cBot §6{0} §cis already online!
 bot.error.botOffline: §cBot §6{0} §cis offline!
 bot.error.botAlreadySaved: §cBot §6{0} §cis already saved!
 bot.error.botNotSaved: §cBot §6{0} is not saved!
-bot.command.spawned: §aBot §6{0} §aspawned
+bot.command.spawned: §aSpawn requested for bot §6{0}
 bot.command.killed: §aBot §6{0} §akilled
 bot.command.action: §aBot §6{0} §aactions run
 bot.command.tag.spawnButton: §aClick to spawn all bots
 bot.command.tag.killButton: §eClick to kill all bots
 bot.command.tag.listButton: §7Click to list all bots
-bot.command.tag.spawn: §6{0} bots with tag §6{1} §aspawned
+bot.command.tag.spawn: §aSpawn requested for §6{0} §abots with tag §6{1}
 bot.command.tag.kill: §6{0} bots with tag §6{1} §akilled
 bot.command.info.configButtonHover: §7Click to configure
 bot.command.info.name: '§7Name: §3{0}'

--- a/src/bot/lang/zh_cn.yml
+++ b/src/bot/lang/zh_cn.yml
@@ -6,7 +6,7 @@ bot.help.content: |
   §6!!bot list [--index <index>] [filters]§7显示假人列表
   §6!!bot spawn <name> §7上线假人
   §6!!bot kill <name> §7下线假人
-  §6!!bot action <name> [index] §7执行假人动作
+  §6!!bot action <name> [index|carpet action] §7执行已保存或一次性 Carpet 动作
   §6!!bot tags §7查看可用标签
   §6!!bot tags <tag> spawn/kill §7上线/下线具有标签的假人
   §6!!bot info <name> §7查看假人信息
@@ -25,13 +25,13 @@ bot.error.botOnline: §c假人 §6{0} §c已在线！
 bot.error.botOffline: §c假人 §6{0} §c不在线！
 bot.error.botAlreadySaved: §c假人 §6{0} §c已保存！
 bot.error.botNotSaved: §c假人 §6{0} §c未保存！
-bot.command.spawned: §a假人 §6{0} §a已上线
+bot.command.spawned: §a已发送假人 §6{0} §a的上线请求
 bot.command.killed: §a假人 §6{0} §a已下线
 bot.command.action: §a假人 §6{0} §a已执行指令
 bot.command.tag.spawnButton: §a点击上线所有假人
 bot.command.tag.killButton: §e点击下线所有假人
 bot.command.tag.listButton: §7点击显示所有假人
-bot.command.tag.spawn: §6{0} §a个具有标签 §6{1} §a的假人已上线
+bot.command.tag.spawn: §a已发送 §6{0} §a个具有标签 §6{1} §a的假人上线请求
 bot.command.tag.kill: §6{0} §a个具有标签 §6{1} §a的假人已下线
 bot.command.info.configButtonHover: §7点击配置
 bot.command.info.name: '§7名称：§3{0}'

--- a/src/bot/mcdreforged.plugin.json
+++ b/src/bot/mcdreforged.plugin.json
@@ -9,7 +9,7 @@
   "author": "Andy Zhang",
   "link": "https://github.com/AnzhiZhang/MCDReforgedPlugins/tree/master/src/bot",
   "dependencies": {
-    "mcdreforged": "^2.6.0",
+    "mcdreforged": "^2.12.0",
     "minecraft_data_api": "^1.4.1",
     "more_command_nodes": "^1.1.0"
   },

--- a/src/bot/readme.md
+++ b/src/bot/readme.md
@@ -6,8 +6,14 @@
 
 ## Dependencies
 
+- [MCDReforged](https://github.com/MCDReforged/MCDReforged) 2.12.0 or newer
+- [Carpet](https://github.com/gnembon/fabric-carpet) 1.4.48 or newer
 - [MinecraftDataAPI](https://github.com/MCDReforged/MinecraftDataAPI)
 - [MoreCommandNodes](../more_command_nodes)
+
+The action tree and spawn syntax are aligned with the latest stable Carpet
+[v26.2](https://github.com/gnembon/fabric-carpet/releases/tag/v26.2).
+The relevant command syntax in `v26.3-beta-2` is unchanged from v26.2.
 
 ## Usage
 
@@ -19,7 +25,7 @@
 
 `!!bot kill <name>` Kill bot
 
-`!!bot action <name> [index]` Execute bot action(s)
+`!!bot action <name> [index|carpet action]` Run saved actions or a one-off Carpet action
 
 `!!bot tags` View available tags
 
@@ -82,7 +88,26 @@ Kill bot
 
 ### action
 
-Execute bot action(s)
+Run bot actions. All existing forms remain available:
+
+- `!!bot action <name>` runs every saved action
+- `!!bot action <name> <index>` runs one saved action by index
+- `!!bot action <name> <carpet action>` runs a one-off Carpet action without saving it
+
+Examples:
+
+```text
+!!bot action bot_alex use once
+!!bot action bot_alex attack interval 12
+!!bot action bot_alex look north
+!!bot action bot_alex move forward
+```
+
+The direct form supports the Carpet v26.2 controls `stop`, `use`, `jump`,
+`attack`, `drop`, `dropStack`, `swapHands`, `hotbar`, `mount`, `dismount`,
+`sneak`/`unsneak`, `sprint`/`unsprint`, `look`, `turn`, and `move`.
+Spawning and killing still use `!!bot spawn` and `!!bot kill` so the plugin's
+runtime state remains synchronized.
 
 When `index` is specified, execute specific action(s) instead of all actions
 
@@ -152,6 +177,7 @@ flowchart LR
     start --> action(action)
     action --> action_name("&lt;name&gt;")
     action_name --> action_name_index["&lt;index&gt;"]
+    action_name --> action_name_carpet["&lt;carpet action&gt;"]
 
     start --> tags(tags)
     tags --> tags_tag["&lt;tag&gt;"]
@@ -228,9 +254,23 @@ Default: `0`
 
 Delay time (seconds) for processing after bot joined. If you are using a non-vanilla server, you may need to adjust this value.
 
+### spawn_timeout
+
+Default: `30`
+
+Maximum time in seconds to wait for Carpet's asynchronous fake-player spawn.
+After a timeout the spawn may be retried. Set it to `0` to disable the timeout.
+
 ### permissions
 
 Minimum permission to use corresponding command
+
+## Carpet configuration
+
+The plugin controls fake players through Carpet's official `/player` command.
+Make sure the `commandPlayer` rule is not disabled. On authenticated servers,
+spawning non-existent `bot_*` names also requires `allowSpawningOfflinePlayers`
+to remain `true` (Carpet's default).
 
 ## FastAPI MCDR
 

--- a/src/bot/readme_cn.md
+++ b/src/bot/readme_cn.md
@@ -6,8 +6,14 @@
 
 ## 依赖
 
+- [MCDReforged](https://github.com/MCDReforged/MCDReforged) 2.12.0 或更高版本
+- [Carpet](https://github.com/gnembon/fabric-carpet) 1.4.48 或更高版本
 - [MinecraftDataAPI](https://github.com/MCDReforged/MinecraftDataAPI)
 - [MoreCommandNodes](../more_command_nodes)
+
+当前动作树与生成语法已按 Carpet 最新稳定版
+[v26.2](https://github.com/gnembon/fabric-carpet/releases/tag/v26.2) 更新；
+`v26.3-beta-2` 的相关命令语法与 v26.2 相同。
 
 ## 使用方法
 
@@ -19,7 +25,7 @@
 
 `!!bot kill <name>` 下线假人
 
-`!!bot action <name> [index]` 执行假人动作
+`!!bot action <name> [index|carpet action]` 执行已保存的动作，或直接执行一次 Carpet 动作
 
 `!!bot tags` 查看可用标签
 
@@ -82,7 +88,25 @@ flowchart TD
 
 ### action
 
-执行假人动作
+执行假人动作。原有用法保持不变：
+
+- `!!bot action <name>` 执行全部已保存动作
+- `!!bot action <name> <index>` 执行指定索引的已保存动作
+- `!!bot action <name> <carpet action>` 直接执行一次 Carpet 动作，不修改已保存动作
+
+直接执行示例：
+
+```text
+!!bot action bot_alex use once
+!!bot action bot_alex attack interval 12
+!!bot action bot_alex look north
+!!bot action bot_alex move forward
+```
+
+支持 Carpet v26.2 的 `stop`、`use`、`jump`、`attack`、`drop`、
+`dropStack`、`swapHands`、`hotbar`、`mount`、`dismount`、
+`sneak`/`unsneak`、`sprint`/`unsprint`、`look`、`turn` 和 `move`。
+生成与下线仍使用 `!!bot spawn` 和 `!!bot kill`，以保证插件状态同步。
 
 当指定 `index` 时，执行特定动作而不是全部动作
 
@@ -152,6 +176,7 @@ flowchart LR
     start --> action(action)
     action --> action_name("&lt;name&gt;")
     action_name --> action_name_index["&lt;index&gt;"]
+    action_name --> action_name_carpet["&lt;carpet action&gt;"]
 
     start --> tags(tags)
     tags --> tags_tag["&lt;tag&gt;"]
@@ -228,9 +253,21 @@ flowchart LR
 
 假人上线后延迟处理的时间（秒），如果您使用非原版服务端，可能需要调整该值。
 
+### spawn_timeout
+
+默认值：`30`
+
+等待 Carpet 完成异步假人生成的超时时间（秒）。超时后允许再次尝试生成；设置为 `0` 可禁用超时。
+
 ### permissions
 
 使用对应指令的最低权限
+
+## Carpet 配置
+
+插件通过 Carpet 官方 `/player` 命令控制假人。请确保 `commandPlayer` 未被禁用。
+正版验证服务器若需生成不存在的 `bot_*` 名称，还需要保持
+`allowSpawningOfflinePlayers` 为 `true`（Carpet 默认值）。
 
 ## FastAPI MCDR
 

--- a/tests/test_bot_plugin.py
+++ b/tests/test_bot_plugin.py
@@ -1,0 +1,591 @@
+import pathlib
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+REPOSITORY_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT / 'src' / 'bot'))
+sys.path.insert(0, str(REPOSITORY_ROOT / 'src' / 'more_command_nodes'))
+
+
+# The plugin imports MinecraftDataAPI at package import time, but none of these
+# unit tests query a live Minecraft server.  A module stub keeps the tests
+# independent from optional MCDR plugins installed in the test environment.
+sys.modules.setdefault('minecraft_data_api', types.ModuleType('minecraft_data_api'))
+
+
+# Importing an MCDR entry point normally registers decorated event listeners
+# against the running server.  There is intentionally no running MCDR server
+# in this unit-test process, so make both decorators synchronous no-ops while
+# importing the production modules.
+import mcdreforged.api.decorator as mcdr_decorator
+
+
+def _synchronous_new_thread(arg=None):
+    def decorate(function):
+        function.original = function
+        return function
+
+    return decorate(arg) if callable(arg) else decorate
+
+
+def _inert_event_listener(_event, **_kwargs):
+    return lambda function: function
+
+
+_original_new_thread = mcdr_decorator.new_thread
+_original_event_listener = mcdr_decorator.event_listener
+mcdr_decorator.new_thread = _synchronous_new_thread
+mcdr_decorator.event_listener = _inert_event_listener
+try:
+    from bot.bot import Bot
+    from bot.bot_manager import BotManager
+    from bot.command_handler import CommandHandler
+    from bot.event_handler import CARPET_LOCAL_LOGIN, EventHandler
+    import bot.event_handler as event_handler_module
+    from bot.exceptions import BotOnlineException
+    from bot.location import Location
+finally:
+    mcdr_decorator.new_thread = _original_new_thread
+    mcdr_decorator.event_listener = _original_event_listener
+
+
+from mcdreforged.api.types import CommandSource
+
+
+DEFAULT_PERMISSIONS = {
+    'list': 1,
+    'spawn': 1,
+    'kill': 1,
+    'action': 1,
+    'tags': 1,
+    'info': 1,
+    'save': 2,
+    'del': 2,
+    'config': 2,
+}
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warning_calls = []
+        self.debug_calls = []
+
+    def warning(self, *args, **kwargs):
+        self.warning_calls.append((args, kwargs))
+
+    def debug(self, *args, **kwargs):
+        self.debug_calls.append((args, kwargs))
+
+
+class FakeServer:
+    def __init__(self):
+        self.executed = []
+        self.logger = FakeLogger()
+        self.command_root = None
+        self.help_messages = []
+        self.say_messages = []
+
+    def execute(self, command):
+        self.executed.append(command)
+
+    def register_command(self, root):
+        self.command_root = root
+
+    def register_help_message(self, *args, **kwargs):
+        self.help_messages.append((args, kwargs))
+
+    def rtr(self, key, *args):
+        return (key, args)
+
+    def say(self, message):
+        self.say_messages.append(message)
+
+
+class FakePlugin:
+    def __init__(
+            self,
+            *,
+            force_gamemode=False,
+            gamemode='survival',
+            spawn_timeout=30.0,
+            post_join_delay=0,
+    ):
+        self.server = FakeServer()
+        self.config = SimpleNamespace(
+            force_gamemode=force_gamemode,
+            gamemode=gamemode,
+            spawn_timeout=spawn_timeout,
+            post_join_delay=post_join_delay,
+            permissions=dict(DEFAULT_PERMISSIONS),
+            name_prefix='bot_',
+            name_suffix='',
+        )
+        self.bot_manager = SimpleNamespace(save_data=Mock())
+        self.get_location = Mock()
+
+    @staticmethod
+    def parse_name(name):
+        return name.lower()
+
+
+def make_bot(plugin, *, name='bot_alex', auto_update=False, actions=None):
+    return Bot(
+        plugin,
+        name,
+        Location([1.0, 64.0, -2.5], [90.0, 10.0], 0),
+        '',
+        [] if actions is None else actions,
+        [],
+        False,
+        False,
+        auto_update,
+    )
+
+
+class ImmediateCallbackInvoker:
+    """Minimal ScheduledCallback invoker used after MCDR parses a command."""
+
+    @staticmethod
+    def invoke_sync(callback, args):
+        return callback(*args)
+
+    @staticmethod
+    def invoke_async(callback, args):
+        raise AssertionError(f'Unexpected async command callback: {callback!r}')
+
+
+class FakeCommandSource(CommandSource):
+    def __init__(self, server, permission_level=4):
+        self._server = server
+        self._permission_level = permission_level
+        self.replies = []
+
+    def get_server(self):
+        return self._server
+
+    def get_permission_level(self):
+        return self._permission_level
+
+    def reply(self, message, **kwargs):
+        self.replies.append((message, kwargs))
+
+
+class SpawnCommandTests(unittest.TestCase):
+    def test_saved_bot_spawn_includes_configured_gamemode(self):
+        plugin = FakePlugin(gamemode='survival', force_gamemode=False)
+        bot = make_bot(plugin)
+        bot.set_saved(True)
+
+        bot.spawn()
+
+        self.assertEqual(
+            [
+                'player bot_alex spawn at 1.0 64.0 -2.5 '
+                'facing 90.0 10.0 in minecraft:overworld in survival'
+            ],
+            plugin.server.executed,
+        )
+
+    def test_unsaved_bot_preserves_carpet_default_when_not_forced(self):
+        plugin = FakePlugin(gamemode='survival', force_gamemode=False)
+        bot = make_bot(plugin)
+
+        bot.spawn()
+
+        self.assertEqual(
+            [
+                'player bot_alex spawn at 1.0 64.0 -2.5 '
+                'facing 90.0 10.0 in minecraft:overworld'
+            ],
+            plugin.server.executed,
+        )
+
+    def test_force_gamemode_applies_to_unsaved_bot(self):
+        plugin = FakePlugin(gamemode='adventure', force_gamemode=True)
+        bot = make_bot(plugin)
+
+        bot.spawn()
+
+        self.assertEqual(
+            [
+                'player bot_alex spawn at 1.0 64.0 -2.5 '
+                'facing 90.0 10.0 in minecraft:overworld in adventure'
+            ],
+            plugin.server.executed,
+        )
+
+
+class PendingSpawnTests(unittest.TestCase):
+    def test_pending_spawn_rejects_duplicate_request(self):
+        plugin = FakePlugin(spawn_timeout=30.0)
+        bot = make_bot(plugin)
+
+        with patch('bot.bot.time.monotonic', side_effect=[100.0, 101.0]):
+            bot.spawn()
+            with self.assertRaises(BotOnlineException):
+                bot.spawn()
+
+        self.assertEqual(1, len(plugin.server.executed))
+
+    def test_pending_spawn_expires_and_allows_retry(self):
+        plugin = FakePlugin(spawn_timeout=5.0)
+        bot = make_bot(plugin)
+
+        with patch(
+                'bot.bot.time.monotonic',
+                side_effect=[100.0, 106.0, 107.0]
+        ):
+            bot.spawn()
+            self.assertFalse(bot.spawning)
+            bot.spawn()
+
+        self.assertEqual(2, len(plugin.server.executed))
+        self.assertEqual(1, len(plugin.server.logger.warning_calls))
+        self.assertIn(
+            'Timed out waiting for bot "bot_alex" to join',
+            plugin.server.logger.warning_calls[0][0][0],
+        )
+
+
+class CommandParsingTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = FakePlugin()
+        self.plugin.bot_manager = SimpleNamespace(
+            bots={},
+            action=Mock(),
+            direct_action=Mock(),
+        )
+        CommandHandler(self.plugin)
+        self.root = self.plugin.server.command_root
+        self.source = FakeCommandSource(self.plugin.server)
+
+    def execute(self, command):
+        executions = self.root._entry_execute(self.source, command)
+        # MCDR 2.12 executes callbacks inline; newer releases return a list of
+        # scheduled executions.  Exercise the real parser in either form.
+        if executions is None:
+            return None
+        self.assertEqual(1, len(executions))
+        return executions[0].scheduled_callback.invoke(
+            ImmediateCallbackInvoker()
+        )
+
+    def test_direct_carpet_action_is_parsed_as_action_text(self):
+        self.execute('!!bot action bot_alex use once')
+
+        self.plugin.bot_manager.direct_action.assert_called_once_with(
+            'bot_alex', 'use once'
+        )
+        self.plugin.bot_manager.action.assert_not_called()
+
+    def test_legacy_numeric_index_still_uses_saved_action_path(self):
+        self.execute('!!bot action bot_alex 2')
+
+        self.plugin.bot_manager.action.assert_called_once_with('bot_alex', 2)
+        self.plugin.bot_manager.direct_action.assert_not_called()
+
+
+class EventBotManager:
+    def __init__(self, plugin):
+        self.plugin = plugin
+        self.bots = {}
+
+    def is_in_list(self, name):
+        return name in self.bots
+
+    def get_bot(self, name):
+        return self.bots[name]
+
+    def new_bot(self, name, location):
+        bot = Bot(
+            self.plugin,
+            name,
+            location,
+            '',
+            [],
+            [],
+            False,
+            False,
+            False,
+        )
+        self.bots[name] = bot
+        return bot
+
+    def update_list(self):
+        return None
+
+    def save_data(self):
+        return None
+
+
+class LocalLoginRecognitionTests(unittest.TestCase):
+    def setUp(self):
+        self.plugin = FakePlugin()
+        self.plugin.bot_manager = EventBotManager(self.plugin)
+        self.plugin.get_location.return_value = Location(
+            [0.0, 64.0, 0.0], [0.0, 0.0], 0
+        )
+        event_handler_module.plugin = self.plugin
+
+    def recognize(self, player, address):
+        content = (
+            f'{player}[{address}] logged in with entity id 42 '
+            'at (0.0, 64.0, 0.0)'
+        )
+        EventHandler.on_player_joined(
+            self.plugin.server,
+            player,
+            SimpleNamespace(content=content),
+        )
+        return self.plugin.bot_manager.get_bot(player.lower())
+
+    def test_plain_local_login_is_recognized(self):
+        self.assertIsNotNone(CARPET_LOCAL_LOGIN.search(
+            'bot_plain[local] logged in with entity id 42 '
+            'at (0.0, 64.0, 0.0)'
+        ))
+
+        bot = self.recognize('bot_plain', 'local')
+
+        self.assertTrue(bot.online)
+        self.assertEqual('bot_plain', bot.mc_name)
+
+    def test_local_entity_address_login_is_recognized(self):
+        self.assertIsNotNone(CARPET_LOCAL_LOGIN.search(
+            'bot_entity[local:E:1234] logged in with entity id 42 '
+            'at (0.0, 64.0, 0.0)'
+        ))
+
+        bot = self.recognize('bot_entity', 'local:E:1234')
+
+        self.assertTrue(bot.online)
+        self.assertEqual('bot_entity', bot.mc_name)
+
+    def test_pending_spawn_does_not_consume_normalized_name_collision(self):
+        self.plugin.parse_name = lambda player: (
+            player.lower()
+            if player.lower().startswith('bot_')
+            else f'bot_{player.lower()}'
+        )
+        bot = make_bot(self.plugin, name='bot_alex')
+        self.plugin.bot_manager.bots[bot.name] = bot
+        bot.spawn()
+
+        EventHandler.on_player_joined(
+            self.plugin.server,
+            'alex',
+            SimpleNamespace(content=(
+                'alex[local] logged in with entity id 42 '
+                'at (0.0, 64.0, 0.0)'
+            )),
+        )
+
+        self.assertTrue(bot.spawning)
+        self.assertFalse(bot.online)
+        self.assertEqual(1, len(self.plugin.server.executed))
+        self.assertIn(
+            'Ignored local player "alex"',
+            self.plugin.server.logger.warning_calls[-1][0][0],
+        )
+
+    def test_pending_spawn_requires_local_login_marker(self):
+        bot = make_bot(self.plugin, name='bot_alex')
+        self.plugin.bot_manager.bots[bot.name] = bot
+        bot.spawn()
+
+        EventHandler.on_player_joined(
+            self.plugin.server,
+            'bot_alex',
+            SimpleNamespace(content=(
+                'bot_alex[/127.0.0.1:25565] logged in with entity id 42 '
+                'at (0.0, 64.0, 0.0)'
+            )),
+        )
+
+        self.assertTrue(bot.spawning)
+        self.assertFalse(bot.online)
+
+    def test_exact_local_join_completes_pending_spawn(self):
+        bot = make_bot(self.plugin, name='bot_alex')
+        self.plugin.bot_manager.bots[bot.name] = bot
+        bot.spawn()
+
+        EventHandler.on_player_joined(
+            self.plugin.server,
+            'Bot_Alex',
+            SimpleNamespace(content=(
+                'Bot_Alex[local:E:1234] logged in with entity id 42 '
+                'at (0.0, 64.0, 0.0)'
+            )),
+        )
+
+        self.assertTrue(bot.online)
+        self.assertFalse(bot.spawning)
+        self.assertEqual('Bot_Alex', bot.mc_name)
+
+
+class AutoUpdateKillTests(unittest.TestCase):
+    def test_location_query_failure_does_not_prevent_carpet_kill(self):
+        plugin = FakePlugin()
+        plugin.get_location.side_effect = TimeoutError('query timed out')
+        bot = make_bot(plugin, auto_update=True)
+        original_location = bot.location
+        bot.restore_runtime_state('Bot_Alex', online=True)
+
+        bot.kill()
+
+        self.assertEqual(['player Bot_Alex kill'], plugin.server.executed)
+        self.assertFalse(bot.online)
+        self.assertIs(original_location, bot.location)
+        plugin.bot_manager.save_data.assert_not_called()
+        self.assertEqual(1, len(plugin.server.logger.warning_calls))
+        self.assertTrue(
+            plugin.server.logger.warning_calls[0][1].get('exc_info')
+        )
+
+    def test_kill_command_failure_keeps_online_state(self):
+        plugin = FakePlugin()
+        plugin.server.execute = Mock(side_effect=RuntimeError('kill failed'))
+        bot = make_bot(plugin)
+        bot.restore_runtime_state('Bot_Alex', online=True)
+
+        with self.assertRaisesRegex(RuntimeError, 'kill failed'):
+            bot.kill()
+
+        self.assertTrue(bot.online)
+
+    def test_save_failure_restores_location_and_still_kills(self):
+        plugin = FakePlugin()
+        plugin.get_location.return_value = Location(
+            [10.0, 80.0, 20.0], [0.0, 0.0], 0
+        )
+        plugin.bot_manager.save_data.side_effect = OSError('disk full')
+        bot = make_bot(plugin, auto_update=True)
+        original_location = bot.location
+        bot.restore_runtime_state('Bot_Alex', online=True)
+
+        bot.kill()
+
+        self.assertIs(original_location, bot.location)
+        self.assertEqual(['player Bot_Alex kill'], plugin.server.executed)
+        self.assertFalse(bot.online)
+
+
+class ReloadServer(FakeServer):
+    def __init__(self, saved_bots=None):
+        super().__init__()
+        self.saved_bots = [] if saved_bots is None else saved_bots
+        self.saved_data_loaded = False
+
+    def load_config_simple(self, file_name, **_kwargs):
+        if file_name == 'botList.json':
+            self.saved_data_loaded = True
+            return {'botList': self.saved_bots}
+        return {'botList': []}
+
+
+class HotReloadTests(unittest.TestCase):
+    @staticmethod
+    def make_previous(bot):
+        old_manager = SimpleNamespace(bots={bot.name: bot})
+        return SimpleNamespace(
+            plugin=SimpleNamespace(bot_manager=old_manager)
+        )
+
+    @staticmethod
+    def make_new_plugin(players, saved_bots=None):
+        plugin = FakePlugin()
+        plugin.server = ReloadServer(saved_bots)
+        result = (
+            None
+            if players is None
+            else SimpleNamespace(players=players)
+        )
+        plugin.minecraft_data_api = SimpleNamespace(
+            get_server_player_list=Mock(return_value=result)
+        )
+        return plugin
+
+    def test_online_bot_is_recreated_with_new_plugin_reference(self):
+        old_plugin = FakePlugin()
+        old_bot = make_bot(old_plugin)
+        old_bot.restore_runtime_state('Bot_Alex', online=True)
+        new_plugin = self.make_new_plugin(['Bot_Alex'])
+
+        manager = BotManager(new_plugin, self.make_previous(old_bot))
+        restored = manager.get_bot('bot_alex')
+
+        self.assertIsNot(restored, old_bot)
+        self.assertTrue(restored.online)
+        self.assertEqual('Bot_Alex', restored.mc_name)
+        restored.run_action('jump once')
+        self.assertEqual(
+            ['player Bot_Alex jump once'],
+            new_plugin.server.executed,
+        )
+        self.assertEqual([], old_plugin.server.executed)
+
+    def test_real_player_name_does_not_mark_prefixed_bot_online(self):
+        old_plugin = FakePlugin()
+        old_bot = make_bot(old_plugin, name='bot_alice')
+        old_bot.set_saved(True)
+        new_plugin = self.make_new_plugin(
+            ['Alice'],
+            saved_bots=[old_bot.saving_data],
+        )
+
+        manager = BotManager(new_plugin, self.make_previous(old_bot))
+
+        self.assertFalse(manager.get_bot('bot_alice').online)
+        new_plugin.minecraft_data_api.get_server_player_list \
+            .assert_not_called()
+
+    def test_pending_snapshot_is_restored_without_player_list_query(self):
+        old_plugin = FakePlugin()
+        old_bot = make_bot(old_plugin)
+        old_bot.set_spawning(True)
+        new_plugin = self.make_new_plugin(None)
+
+        manager = BotManager(new_plugin, self.make_previous(old_bot))
+
+        restored = manager.get_bot('bot_alex')
+        self.assertTrue(restored.spawning)
+        self.assertFalse(restored.online)
+        new_plugin.minecraft_data_api.get_server_player_list \
+            .assert_not_called()
+
+    def test_confirmed_online_state_is_restored_without_list_snapshot(self):
+        old_plugin = FakePlugin()
+        old_bot = make_bot(old_plugin)
+        old_bot.restore_runtime_state('Bot_Alex', online=True)
+        new_plugin = self.make_new_plugin([])
+
+        manager = BotManager(new_plugin, self.make_previous(old_bot))
+
+        self.assertTrue(manager.get_bot('bot_alex').online)
+        new_plugin.minecraft_data_api.get_server_player_list \
+            .assert_not_called()
+
+    def test_persistent_data_is_loaded_without_player_list_query(self):
+        saved_plugin = FakePlugin()
+        saved_bot = make_bot(saved_plugin)
+        saved_bot.set_saved(True)
+        new_plugin = self.make_new_plugin(
+            None,
+            saved_bots=[saved_bot.saving_data],
+        )
+
+        manager = BotManager(new_plugin, self.make_previous(saved_bot))
+
+        self.assertTrue(new_plugin.server.saved_data_loaded)
+        self.assertTrue(manager.get_bot('bot_alex').saved)
+        new_plugin.minecraft_data_api.get_server_player_list \
+            .assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 中文

### 变更内容

- 按 Carpet v26.2 的官方 `/player` 命令树补充一次性动作调用，例如：
  - `!!bot action <Bot> use once`
  - `!!bot action <Bot> attack interval 12`
- 完整保留原有 `!!bot action <name>` 和 `!!bot action <name> <index>` 用法；生成和下线仍通过插件原有的 `spawn` / `kill` 命令管理。
- 在生成命令中原子传入已配置的游戏模式，避免控制台默认创造模式与加入后切换模式之间的竞态。
- 为 Carpet 的异步 GameProfile 解析增加 pending 状态和可配置的 `spawn_timeout`，防止重复生成请求。
- 仅在 local 登录标记及精确请求名同时匹配时完成 pending 生成，避免名称前后缀归一化误命中真人玩家。
- 热重载时同步载入持久化数据，并使用绑定到新插件实例的 Bot 对象恢复已确认的在线/pending 状态。
- 自动更新位置失败时保留旧位置并继续执行 kill；kill 命令失败时不错误地标记为离线。
- 加强 MinecraftDataAPI 位置数据的缺失字段、维度和值形状检查。
- 更新中英文帮助、README 和本地化文本，并增加 20 项回归测试。

### 背景与原因

新版 Carpet 的假人生成可能异步解析 GameProfile；同时，控制台未显式指定游戏模式时会使用创造模式。原插件依赖加入后的二次 `gamemode` 命令，因此存在假人短暂或持续处于创造模式、重复生成以及热重载状态失真的竞态。原动作命令也只能执行预先保存的动作，无法直接表达 Carpet 当前支持的动作参数。

本改动以 Carpet v26.2 的 `PlayerCommand` 为准，并核对了 v26.3-beta-2 的相关命令与假人实现文件，两者在这些接口上没有差异。

### 兼容性与影响

- 原有命令形式、权限项和 `botList.json` 数据结构保持不变。
- 新的一次性 Carpet 动作语法是可选扩展，不会修改已保存的动作列表。
- 新增配置 `spawn_timeout`，旧配置会使用默认值 `30.0` 秒。
- 将 MCDReforged 最低依赖声明修正为 `^2.12.0`；现有命令树已使用 2.12 才引入的 `CountingLiteral`。
- 版本号与 CHANGELOG 继续交由仓库现有的 Release Please 流程生成。

### 验证

- MCDReforged 2.15.7：20/20 单元测试通过。
- MCDReforged 2.12.0：20/20 单元测试通过。
- `compileall` 通过。
- Ruff 高严重度语法/未定义名称检查通过。
- JSON、YAML、双语 locale 键和占位符校验通过。
- `git diff --check` 通过。

## English

### What changed

- Added one-off actions matching Carpet v26.2's official `/player` command tree, for example:
  - `!!bot action <Bot> use once`
  - `!!bot action <Bot> attack interval 12`
- Fully preserved the existing `!!bot action <name>` and `!!bot action <name> <index>` forms. Spawning and killing still use the plugin's existing `spawn` / `kill` commands.
- Passed the configured game mode atomically in the spawn command, avoiding the race between Carpet's console default and the post-join game-mode update.
- Added a pending state and configurable `spawn_timeout` for Carpet's asynchronous GameProfile resolution, preventing duplicate spawn requests.
- Required both a local-login marker and an exact requested name before completing a pending spawn, preventing prefix/suffix normalization from matching a real player.
- Made persistent loading synchronous and restored confirmed online/pending state with fresh Bot objects bound to the new plugin instance during hot reloads.
- Kept the previous location and continued killing when auto-update fails; a failed kill command no longer marks the bot offline incorrectly.
- Added validation for missing MinecraftDataAPI fields, dimensions, and malformed position/rotation values.
- Updated English and Chinese help, README, and locale text, with 20 regression tests.

### Why

Recent Carpet versions may resolve a fake player's GameProfile asynchronously, while console-issued spawns default to creative mode unless a mode is supplied. The previous post-join `gamemode` update left races around game mode, duplicate spawning, and reload state. The action command also only ran pre-saved actions and could not directly express Carpet's current action arguments.

This change follows Carpet v26.2's `PlayerCommand`. The relevant command and fake-player implementation files were also compared with v26.3-beta-2 and are unchanged for these interfaces.

### Compatibility and impact

- Existing command forms, permissions, and the `botList.json` schema remain unchanged.
- One-off Carpet actions are an optional extension and do not modify saved actions.
- The new `spawn_timeout` option defaults to `30.0` seconds for existing configurations.
- The declared MCDReforged minimum is corrected to `^2.12.0`; the existing command tree already uses `CountingLiteral`, introduced in 2.12.
- Version and CHANGELOG updates remain managed by the repository's existing Release Please workflow.

### Validation

- MCDReforged 2.15.7: 20/20 unit tests passed.
- MCDReforged 2.12.0: 20/20 unit tests passed.
- `compileall` passed.
- Ruff high-severity syntax/undefined-name checks passed.
- JSON, YAML, and bilingual locale key/placeholder validation passed.
- `git diff --check` passed.

Closes #277
