### PR TITLE
[MCDR Command HTTP API] 响应中新增 reply 相关字段

### DIFF
--- a/src/mcdr_command_http_api/mcdr_command_http_api/__init__.py
+++ b/src/mcdr_command_http_api/mcdr_command_http_api/__init__.py
@@ -1,6 +1,16 @@
+import asyncio
+import weakref
+from time import time_ns
+from typing import override, Optional
+
 from fastapi import FastAPI, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from mcdreforged import PluginCommandSource, RTextBase, ServerInterface
 from mcdreforged.api.types import PluginServerInterface
+from mcdreforged.plugin.type.plugin import AbstractPlugin
+from mcdreforged.utils import misc_utils
+from mcdreforged.utils.string_utils import clean_minecraft_color_code
+from mcdreforged.utils.types.message import MessageText
 from pydantic import BaseModel
 
 from .config import Config
@@ -12,8 +22,37 @@ __server: PluginServerInterface
 __config: Config
 
 
+class _ReplayHolder:
+    def __init__(self):
+        self.replays: list[str] = []
+        self.done_event = asyncio.Event()
+
+
+class FastAPICommandSource(PluginCommandSource):
+    def __init__(self, server: 'ServerInterface', plugin: Optional['AbstractPlugin'] = None):
+        self.holder = _ReplayHolder()
+        self._finalize = weakref.finalize(self, self.holder.done_event.set)
+        super().__init__(server, plugin)
+
+    @override
+    def reply(self, message: MessageText, **kwargs) -> None:
+        if self.holder.done_event.is_set():
+            self.get_server().logger.warning(
+                f"the fallowing reply(id: {id(self.holder.replays)}) can't reach to http response: "
+            )
+            misc_utils.print_text_to_console(self.get_server().logger, message)
+        self.holder.replays.append(clean_minecraft_color_code(
+            message.to_plain_text() if isinstance(message, RTextBase) else message
+        ))
+
+    @staticmethod
+    def from_server_interface(server: PluginServerInterface) -> 'FastAPICommandSource':
+        return FastAPICommandSource(server, server.get_plugin_instance(server.get_self_metadata().id))
+
+
 class ExecuteRequest(BaseModel):
     command: str
+    timeout: int = 10_000
 
 
 def verify_token(credentials: HTTPAuthorizationCredentials = Security(bearer_scheme)):
@@ -27,8 +66,41 @@ async def execute_command(
         request: ExecuteRequest,
         _token: str = Security(verify_token),
 ):
-    __server.execute_command(request.command)
-    return {"status": "ok", "command": request.command}
+    time_before_execute = time_ns()
+    source = FastAPICommandSource.from_server_interface(__server)
+    holder = source.holder  # add references of holder
+    __server.execute_command(request.command, source)
+    del source  # remove source's references
+
+    time_time_before_wait = time_ns()
+    # In normal cases, the reference count of `source` at this line has already to 0.
+    # But if the Command Callback passes `source` to another thread
+    # or put outside of Command Callback scope
+    # causing `source` not to be finalized, then the following waiting logic will be executed.
+    try:
+        await asyncio.wait_for(holder.done_event.wait(), timeout=request.timeout / 1000)
+    except asyncio.TimeoutError:
+        __server.logger.info(
+            f"source.reply timeout, {len(holder.replays)} line(s) reply "
+            f"will be response, reply_id: {id(holder.replays)}"
+        )
+
+    time_before_response = time_ns()
+    __server.logger.debug(
+        f"Total cost: {(time_before_response - time_before_execute)/1_000_000}ms, "
+        f"command handler cost: {(time_time_before_wait - time_before_execute)/1_000_000}ms, "
+        f"wait cost: {(time_before_response - time_time_before_wait)/1_000_000}ms."
+    )
+
+    return {
+        "status": "ok",
+        "command": request.command,
+        "reply": {
+            "id": id(holder.replays),
+            "is_finished": holder.done_event.is_set(),
+            "messages": holder.replays,
+        }
+    }
 
 
 def on_load(server: PluginServerInterface, prev_module):

--- a/src/mcdr_command_http_api/readme.md
+++ b/src/mcdr_command_http_api/readme.md
@@ -36,22 +36,55 @@ Authorization: Bearer <token>
 
 ```json
 {
-  "command": "!!MCDR status"
+  "command": "!!MCDR status",
+  "timeout": 10000
 }
 ```
 
 | 字段 | 类型 | 说明 |
 | - | - | - |
 | `command` | `string` | 要执行的 MCDR 命令 |
+| `timeout` | `int` | 等待回复的最长时间（ms） |
 
 #### 响应
 
 ```json
 {
-  "status": "ok",
-  "command": "!!MCDR status"
+    "status": "ok",
+    "command": "!!MCDR status",
+    "reply": {
+        "id": 2178126035648,
+        "is_finished": false,
+        "messages": [
+            "MCDReforged version: 2.15.7",
+            "MCDR state: Running",
+            "Server state: Running",
+            "Server startup: True",
+            "Exit after server stops: True",
+            "Rcon: Offline",
+            "Plugin count: 5",
+            "Server PID: 26804",
+            "  cmd.exe: 26804",
+            "  └── java.exe: 53608",
+            "Info queue load: 0/2048",
+            "Task queue load: 0/1048576",
+            "Thread count: 13"
+        ]
+    }
 }
 ```
+##### reply 获取逻辑
+- 大部分插件的命令均能正常响应：即命令回调函数正常释放了 `CommandSource`;
+- 若命令回调函数执行结束后 `CommandSource` 未被释放，则不保证能收到全部消息，且在 `timeout`毫秒后的消息会被丢弃，以下为可能的技术细节：
+  - 命令回调函数将 `CommandSource` 放到了新的线程，命令回调函数返回后仍然通过 `CommandSource.reply` 回复消息；
+  - 命令回调函数创建了 `CommandSource` 的作用域外部的应用，如将 `CommandSource` 放到了全局列表，且后续有其他方法通过 `CommandSource.reply` 回复消息。
+
+##### reply 结构
+| 字段 | 类型 | 说明 |
+| - | - | - |
+| `id` | int | 回复 ID |
+| `is_finished` | bool | 是否返回了命令的全部回复，true: 一定得收集了全部回复，false: 不保证回复完整性 |
+| `messages` | list[str] | 回复消息 |
 
 #### 错误码
 


### PR DESCRIPTION
通过自定义 `CommandSource` 收集 `CommandSource.reply(...)` 的回复消息，并在 `CommandSource` 引用计数归零时响应。

默认情况下的执行流程是：

```
HTTP POST 请求
      |
server.execute_command(request.command, source)
      | <1>
从 source 中取出 source.reply() 回复的消息并返回
```

运行到<1>时， Command Callback 已执行完成，通过 `del source` 释放当前上下文的 `source` 引用，大部分情况下 `source` 引用计数归零，即不会再有 reply 消息。

以下两种情况引用计数不会归零：
1. `source` 被传入了其他线程；
2. `source` 被Command Callback添加了其作用域外的引用；

以上情况可能导致等待时间无限延长，但 HTTP response 不可能无限等待，所以需要一个 `timeout` 参数来控制 <1> 处的最长等待时间 。由于 python 在引用计数归零时会立刻回收对象，因此在 <1> 出等待至多 `timeout` ms，若 `source` 被回收，则立刻 response 已收集的 reply。

若超过了等待时间都没有返回，则在返回的`reply.is_finished` 将其标记为不保证完整。

这是个测试用的插件，使用 `!!irc sub_thread` 和 `!!irc global_reference` 测试上述引用计数不会归零的两种情况：
[irregular_commands.py](https://github.com/user-attachments/files/30180160/irregular_commands.py)